### PR TITLE
fix: clear README to prevent appending to stale state

### DIFF
--- a/.github/workflows/notable-date-cronjob.yml
+++ b/.github/workflows/notable-date-cronjob.yml
@@ -22,6 +22,11 @@ jobs:
         # This prebuilt GitHub action checks-out your repository so your workflow can access it.
         uses: actions/checkout@v4
 
+      - name: Clear Existing README
+        # We start with a clean slate each day to prevent appending to yesterday's content
+        # if other steps conditionally skip writing.
+        run: rm -f README.md
+
       - name: Check Date
         id: date-check # The [id] makes this step accessible in later steps for referencing outputs or status.
         run: |


### PR DESCRIPTION
When the NASA astronomy picture of the day is a video instead of an image, the workflow correctly skipped adding it to the README. However, because it relied on overwriting the checkout-provided README, skipping the step meant the old README persisted into the Word of the Day step. WOTD saw the old README existed and inappropriately appended to it instead of starting a new document. Adding an explicit removal of `README.md` after checkout ensures we always build on a clean slate.